### PR TITLE
Add namespace restore plugin for scc annotations

### DIFF
--- a/velero-plugins/main.go
+++ b/velero-plugins/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"github.com/fusor/openshift-migration-plugin/velero-plugins/migdeployment"
 	"github.com/fusor/openshift-migration-plugin/velero-plugins/migdeploymentconfig"
+	"github.com/fusor/openshift-migration-plugin/velero-plugins/migimagestream"
+	"github.com/fusor/openshift-migration-plugin/velero-plugins/migimagestreamtag"
+	"github.com/fusor/openshift-migration-plugin/velero-plugins/mignamespace"
 	"github.com/fusor/openshift-migration-plugin/velero-plugins/migpod"
 	"github.com/fusor/openshift-migration-plugin/velero-plugins/migpv"
 	"github.com/fusor/openshift-migration-plugin/velero-plugins/migpvc"
-	"github.com/fusor/openshift-migration-plugin/velero-plugins/migimagestream"
-	"github.com/fusor/openshift-migration-plugin/velero-plugins/migimagestreamtag"
 	"github.com/fusor/openshift-velero-plugin/velero-plugins/build"
 	"github.com/fusor/openshift-velero-plugin/velero-plugins/common"
 	"github.com/fusor/openshift-velero-plugin/velero-plugins/daemonset"
@@ -22,10 +23,12 @@ import (
 	veleroplugin "github.com/heptio/velero/pkg/plugin/framework"
 	"github.com/sirupsen/logrus"
 )
+
 func main() {
 	veleroplugin.NewServer().
 		RegisterBackupItemAction("openshift.io/01-common-backup-plugin", newCommonBackupPlugin).
 		RegisterRestoreItemAction("openshift.io/01-common-restore-plugin", newCommonRestorePlugin).
+		RegisterRestoreItemAction("openshift.io/01-namespace-restore-plugin", newNamespaceRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/02-serviceaccount-restore-plugin", newServiceAccountRestorePlugin).
 		RegisterBackupItemAction("openshift.io/02-pv-backup-plugin", newPVBackupPlugin).
 		RegisterRestoreItemAction("openshift.io/03-pv-restore-plugin", newPVRestorePlugin).
@@ -54,6 +57,10 @@ func newCommonBackupPlugin(logger logrus.FieldLogger) (interface{}, error) {
 
 func newCommonRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
 	return &common.RestorePlugin{Log: logger}, nil
+}
+
+func newNamespaceRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
+	return &mignamespace.RestorePlugin{Log: logger}, nil
 }
 
 func newBuildRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {

--- a/velero-plugins/migcommon/types.go
+++ b/velero-plugins/migcommon/types.go
@@ -9,6 +9,7 @@ const MigrateTypeAnnotation string = "openshift.io/migrate-type"
 
 // target storage class
 const MigrateStorageClassAnnotation string = "openshift.io/target-storage-class"
+
 //target access mode
 const MigrateAccessModeAnnotation string = "openshift.io/target-access-mode"
 
@@ -22,3 +23,8 @@ const PodStageLabel string = "migration-stage-pod"
 // Restic annotations
 const ResticRestoreAnnotationPrefix string = "snapshot.velero.io"
 const ResticBackupAnnotation string = "backup.velero.io/backup-volumes"
+
+// Namespace SCC annotations
+const NamespaceSCCAnnotationMCS string = "openshift.io/sa.scc.mcs"
+const NamespaceSCCAnnotationGroups string = "openshift.io/sa.scc.supplemental-groups"
+const NamespaceSCCAnnotationUidRange string = "openshift.io/sa.scc.uid-range"

--- a/velero-plugins/mignamespace/restore.go
+++ b/velero-plugins/mignamespace/restore.go
@@ -1,0 +1,50 @@
+package mignamespace
+
+import (
+	"encoding/json"
+
+	"github.com/fusor/openshift-migration-plugin/velero-plugins/migcommon"
+	"github.com/heptio/velero/pkg/plugin/velero"
+	"github.com/sirupsen/logrus"
+	corev1API "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// RestorePlugin is a restore item action plugin for Velero
+type RestorePlugin struct {
+	Log logrus.FieldLogger
+}
+
+// AppliesTo returns a velero.ResourceSelector that applies to namespaces
+func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"namespaces"},
+	}, nil
+}
+
+// Execute action for the restore plugin for the namespace resource
+func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	p.Log.Info("[ns-restore] Entering Namespace restore plugin")
+
+	namespace := corev1API.Namespace{}
+	originalNamespace := corev1API.Namespace{}
+
+	itemMarshal, _ := json.Marshal(input.Item)
+	json.Unmarshal(itemMarshal, &namespace)
+	itemMarshal, _ = json.Marshal(input.ItemFromBackup)
+	json.Unmarshal(itemMarshal, &originalNamespace)
+
+	p.Log.Infof("[ns-restore] namespace: %s", namespace.Name)
+	// Preserve scc annotations
+	annotations := make(map[string]string)
+	annotations[migcommon.NamespaceSCCAnnotationMCS] = originalNamespace.Annotations[migcommon.NamespaceSCCAnnotationMCS]
+	annotations[migcommon.NamespaceSCCAnnotationGroups] = originalNamespace.Annotations[migcommon.NamespaceSCCAnnotationGroups]
+	annotations[migcommon.NamespaceSCCAnnotationUidRange] = originalNamespace.Annotations[migcommon.NamespaceSCCAnnotationUidRange]
+	namespace.Annotations = annotations
+
+	var out map[string]interface{}
+	objrec, _ := json.Marshal(namespace)
+	json.Unmarshal(objrec, &out)
+
+	return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: out}), nil
+}


### PR DESCRIPTION
This PR preserves the SCC annotations present on a namespace when migrating.