### PR TITLE
handle PVCs generated using volume.beta.kubernetes.io/storage-class

### DIFF
--- a/velero-plugins/migpvc/restore.go
+++ b/velero-plugins/migpvc/restore.go
@@ -47,6 +47,9 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 			pvc.Spec.StorageClassName = nil
 		} else {
 			pvc.Spec.StorageClassName = &storageClassName
+			if pvc.Annotations[corev1API.BetaStorageClassAnnotation] != "" {
+				pvc.Annotations[corev1API.BetaStorageClassAnnotation] = storageClassName
+			}
 		}
 		accessMode := pvc.Annotations[migcommon.MigrateAccessModeAnnotation]
 		if accessMode != "" {


### PR DESCRIPTION
The initial PVC restore plugin just modifies Spec.StorageClassName
to restore the pvc to the desired target storageclass. In cases
where PVCs were specified on the src cluster using the (deprecated)
volume.beta.kubernetes.io/storage-class annotation rather than
Spec.StorageClassName, we weren't changing that, and as a result
post-restore, the PVC got created with the old src storage class
rather than the desired target storageclass.

This commit fixes the problem by also modifying the annotation
if it exists on the pvc at restore.