### PR TITLE
Strip selected-node annotation on PVC restore

### DIFF
--- a/velero-plugins/migcommon/types.go
+++ b/velero-plugins/migcommon/types.go
@@ -20,6 +20,9 @@ const MigrateQuiesceAnnotation string = "openshift.io/migrate-quiesce-pods"
 
 const PodStageLabel string = "migration-stage-pod"
 
+// kubernetes PVC annotations
+const PVCSelectedNodeAnnotation string = "volume.kubernetes.io/selected-node"
+
 // Restic annotations
 const ResticRestoreAnnotationPrefix string = "snapshot.velero.io"
 const ResticBackupAnnotation string = "backup.velero.io/backup-volumes"

--- a/velero-plugins/migpvc/restore.go
+++ b/velero-plugins/migpvc/restore.go
@@ -56,6 +56,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 			pvc.Spec.AccessModes = []corev1API.PersistentVolumeAccessMode{corev1API.PersistentVolumeAccessMode(accessMode)}
 		}
 	}
+	delete(pvc.Annotations, migcommon.PVCSelectedNodeAnnotation)
 
 	var out map[string]interface{}
 	objrec, _ := json.Marshal(pvc)


### PR DESCRIPTION
Strip volume.kubernetes.io/selected-node annotation on PVC
restore. Backups done on OCP4 might specify this, and if present
the PVC will fail on restore into a cluster where the listed
node isn't found.

Fixes #17