### PR TITLE
Automatically convert schema1 images to schema2 on copy

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -90,8 +90,7 @@
   revision = "1097c8bae83b84cf3dfccfcc542e06c8c28ea3f4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:930807c0a9bb3bc57d1d95fb9f11a335f7c6daab3ad01da698107b4d7bdc2ca6"
+  digest = "1:916fe82a562ed158f70a8bd057bcfaf3df6c464cecb0bff4a12b2690782cf45c"
   name = "github.com/containers/image"
   packages = [
     "v5/copy",
@@ -133,7 +132,7 @@
     "v5/version",
   ]
   pruneopts = "NUT"
-  revision = "bcb936db8986dd7547bc244ab5c2306d445e6fd9"
+  revision = "6dbed6e4847ccda0a82a8b72de66e6257fb0edda"
 
 [[projects]]
   branch = "master"
@@ -1200,6 +1199,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/containers/image/v5/copy",
+    "github.com/containers/image/v5/manifest",
     "github.com/containers/image/v5/signature",
     "github.com/containers/image/v5/transports/alltransports",
     "github.com/containers/image/v5/types",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -101,7 +101,7 @@
 
 [[override]]
   name = "github.com/containers/image"
-  branch = "master"
+  revision = "6dbed6e4847ccda0a82a8b72de66e6257fb0edda"
 
 [[override]]
   name = "github.com/opencontainers/image-spec"

--- a/velero-plugins/migimagestream/restore.go
+++ b/velero-plugins/migimagestream/restore.go
@@ -105,14 +105,14 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
 }
 
-func copyImageRestore(src, dest string) (string, error) {
+func copyImageRestore(src, dest string) ([]byte, error) {
 	sourceCtx, err := migrationRegistrySystemContext()
 	if err != nil {
-		return "", err
+		return []byte{}, err
 	}
 	destinationCtx, err := internalRegistrySystemContext()
 	if err != nil {
-		return "", err
+		return []byte{}, err
 	}
 	return copyImage(src, dest, sourceCtx, destinationCtx)
 }

--- a/velero-plugins/migimagestream/shared.go
+++ b/velero-plugins/migimagestream/shared.go
@@ -14,26 +14,26 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func copyImage(src, dest string, sourceCtx, destinationCtx *types.SystemContext) (string, error) {
+func copyImage(src, dest string, sourceCtx, destinationCtx *types.SystemContext) ([]byte, error) {
 	policyContext, err := getPolicyContext()
 	if err != nil {
-		return "", fmt.Errorf("Error loading trust policy: %v", err)
+		return []byte{}, fmt.Errorf("Error loading trust policy: %v", err)
 	}
 	defer policyContext.Destroy()
 
 	srcRef, err := alltransports.ParseImageName(src)
 	if err != nil {
-		return "", fmt.Errorf("Invalid source name %s: %v", src, err)
+		return []byte{}, fmt.Errorf("Invalid source name %s: %v", src, err)
 	}
 	destRef, err := alltransports.ParseImageName(dest)
 	if err != nil {
-		return "", fmt.Errorf("Invalid destination name %s: %v", dest, err)
+		return []byte{}, fmt.Errorf("Invalid destination name %s: %v", dest, err)
 	}
 	manifest, err := copy.Image(context.Background(), policyContext, destRef, srcRef, &copy.Options{
 		SourceCtx:      sourceCtx,
 		DestinationCtx: destinationCtx,
 	})
-	return string(manifest), err
+	return manifest, err
 }
 
 func getPolicyContext() (*signature.PolicyContext, error) {
@@ -52,6 +52,7 @@ func internalRegistrySystemContext() (*types.SystemContext, error) {
 	ctx := &types.SystemContext{
 		DockerDaemonInsecureSkipTLSVerify: true,
 		DockerInsecureSkipTLSVerify:       types.OptionalBoolTrue,
+		DockerDisableDestSchema1MIMETypes: true,
 		DockerAuthConfig: &types.DockerAuthConfig{
 			Username: "ignored",
 			Password: config.BearerToken,
@@ -64,6 +65,7 @@ func migrationRegistrySystemContext() (*types.SystemContext, error) {
 	ctx := &types.SystemContext{
 		DockerDaemonInsecureSkipTLSVerify: true,
 		DockerInsecureSkipTLSVerify:       types.OptionalBoolTrue,
+		DockerDisableDestSchema1MIMETypes: true,
 	}
 	return ctx, nil
 }

--- a/vendor/github.com/containers/image/v5/docker/docker_client.go
+++ b/vendor/github.com/containers/image/v5/docker/docker_client.go
@@ -45,6 +45,10 @@ const (
 
 	extensionSignatureSchemaVersion = 2        // extensionSignature.Version
 	extensionSignatureTypeAtomic    = "atomic" // extensionSignature.Type
+
+	backoffNumIterations = 5
+	backoffInitialDelay  = 2 * time.Second
+	backoffMaxDelay      = 60 * time.Second
 )
 
 var systemPerHostCertDirPaths = [2]string{"/etc/containers/certs.d", "/etc/docker/certs.d"}
@@ -277,7 +281,7 @@ func CheckAuth(ctx context.Context, sys *types.SystemContext, username, password
 	}
 	defer resp.Body.Close()
 
-	return httpResponseToError(resp)
+	return httpResponseToError(resp, "")
 }
 
 // SearchResult holds the information of each matching image
@@ -351,7 +355,7 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 		} else {
 			defer resp.Body.Close()
 			if resp.StatusCode != http.StatusOK {
-				logrus.Debugf("error getting search results from v1 endpoint %q: %v", registry, httpResponseToError(resp))
+				logrus.Debugf("error getting search results from v1 endpoint %q: %v", registry, httpResponseToError(resp, ""))
 			} else {
 				if err := json.NewDecoder(resp.Body).Decode(v1Res); err != nil {
 					return nil, err
@@ -368,7 +372,7 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 	} else {
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			logrus.Errorf("error getting search results from v2 endpoint %q: %v", registry, httpResponseToError(resp))
+			logrus.Errorf("error getting search results from v2 endpoint %q: %v", registry, httpResponseToError(resp, ""))
 		} else {
 			if err := json.NewDecoder(resp.Body).Decode(v2Res); err != nil {
 				return nil, err
@@ -400,74 +404,64 @@ func (c *dockerClient) makeRequest(ctx context.Context, method, path string, hea
 	return c.makeRequestToResolvedURL(ctx, method, url, headers, stream, -1, auth, extraScope)
 }
 
+// parseRetryAfter determines the delay required by the "Retry-After" header in res and returns it,
+// silently falling back to fallbackDelay if the header is missing or invalid.
+func parseRetryAfter(res *http.Response, fallbackDelay time.Duration) time.Duration {
+	after := res.Header.Get("Retry-After")
+	if after == "" {
+		return fallbackDelay
+	}
+	logrus.Debugf("Detected 'Retry-After' header %q", after)
+	// First, check if we have a numerical value.
+	if num, err := strconv.ParseInt(after, 10, 64); err == nil {
+		return time.Duration(num) * time.Second
+	}
+	// Second, check if we have an HTTP date.
+	// If the delta between the date and now is positive, use it.
+	// Otherwise, fall back to using the default exponential back off.
+	if t, err := http.ParseTime(after); err == nil {
+		delta := time.Until(t)
+		if delta > 0 {
+			return delta
+		}
+		logrus.Debugf("Retry-After date in the past, ignoring it")
+		return fallbackDelay
+	}
+	// If the header contents are bogus, fall back to using the default exponential back off.
+	logrus.Debugf("Invalid Retry-After format, ignoring it")
+	return fallbackDelay
+}
+
 // makeRequestToResolvedURL creates and executes a http.Request with the specified parameters, adding authentication and TLS options for the Docker client.
 // streamLen, if not -1, specifies the length of the data expected on stream.
 // makeRequest should generally be preferred.
-// In case of an http 429 status code in the response, it performs an exponential back off starting at 2 seconds for at most 5 iterations.
-// If the `Retry-After` header is set in the response, the specified value or date is
-// If the stream is non-nil, no back off will be performed.
+// In case of an HTTP 429 status code in the response, it may automatically retry a few times.
 // TODO(runcom): too many arguments here, use a struct
 func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url string, headers map[string][]string, stream io.Reader, streamLen int64, auth sendAuth, extraScope *authScope) (*http.Response, error) {
-	var (
-		res   *http.Response
-		err   error
-		delay int64
-	)
-	delay = 2
-	const numIterations = 5
-	const maxDelay = 60
+	delay := backoffInitialDelay
+	attempts := 0
+	for {
+		res, err := c.makeRequestToResolvedURLOnce(ctx, method, url, headers, stream, streamLen, auth, extraScope)
+		attempts++
+		if res == nil || res.StatusCode != http.StatusTooManyRequests || // Only retry on StatusTooManyRequests, success or other failure is returned to caller immediately
+			stream != nil || // We can't retry with a body (which is not restartable in the general case)
+			attempts == backoffNumIterations {
+			return res, err
+		}
 
-	// math.Min() only supports float64, so have an anonymous func to avoid
-	// casting.
-	min := func(a int64, b int64) int64 {
-		if a < b {
-			return a
+		delay = parseRetryAfter(res, delay)
+		if delay > backoffMaxDelay {
+			delay = backoffMaxDelay
 		}
-		return b
+		logrus.Debugf("Too many requests to %s: sleeping for %f seconds before next attempt", url, delay.Seconds())
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+			// Nothing
+		}
+		delay = delay * 2 // exponential back off
 	}
-
-	nextDelay := func(r *http.Response, delay int64) int64 {
-		after := res.Header.Get("Retry-After")
-		if after == "" {
-			return min(delay, maxDelay)
-		}
-		logrus.Debugf("detected 'Retry-After' header %q", after)
-		// First check if we have a numerical value.
-		if num, err := strconv.ParseInt(after, 10, 64); err == nil {
-			return min(num, maxDelay)
-		}
-		// Secondly check if we have an http date.
-		// If the delta between the date and now is positive, use it.
-		// Otherwise, fall back to using the default exponential back off.
-		if t, err := http.ParseTime(after); err == nil {
-			delta := int64(time.Until(t).Seconds())
-			if delta > 0 {
-				return min(delta, maxDelay)
-			}
-			logrus.Debugf("negative date: falling back to using %d seconds", delay)
-			return min(delay, maxDelay)
-		}
-		// If the header contains bogus, fall back to using the default
-		// exponential back off.
-		logrus.Debugf("invalid format: falling back to using %d seconds", delay)
-		return min(delay, maxDelay)
-	}
-
-	for i := 0; i < numIterations; i++ {
-		res, err = c.makeRequestToResolvedURLOnce(ctx, method, url, headers, stream, streamLen, auth, extraScope)
-		if stream == nil && res != nil && res.StatusCode == http.StatusTooManyRequests {
-			if i < numIterations-1 {
-				logrus.Errorf("HEADER %v", res.Header)
-				delay = nextDelay(res, delay) // compute next delay - does NOT exceed maxDelay
-				logrus.Debugf("too many request to %s: sleeping for %d seconds before next attempt", url, delay)
-				time.Sleep(time.Duration(delay) * time.Second)
-				delay = delay * 2 // exponential back off
-			}
-			continue
-		}
-		break
-	}
-	return res, err
 }
 
 // makeRequestToResolvedURLOnce creates and executes a http.Request with the specified parameters, adding authentication and TLS options for the Docker client.
@@ -627,7 +621,7 @@ func (c *dockerClient) detectPropertiesHelper(ctx context.Context) error {
 		defer resp.Body.Close()
 		logrus.Debugf("Ping %s status %d", url, resp.StatusCode)
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
-			return httpResponseToError(resp)
+			return httpResponseToError(resp, "")
 		}
 		c.challenges = parseAuthHeader(resp.Header)
 		c.scheme = scheme

--- a/vendor/github.com/containers/image/v5/docker/docker_image.go
+++ b/vendor/github.com/containers/image/v5/docker/docker_image.go
@@ -70,7 +70,7 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 			return nil, err
 		}
 		defer res.Body.Close()
-		if err := httpResponseToError(res); err != nil {
+		if err := httpResponseToError(res, "Error fetching tags list"); err != nil {
 			return nil, err
 		}
 

--- a/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
@@ -58,14 +58,16 @@ func (d *dockerImageDestination) Close() error {
 }
 
 func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
-	return []string{
+	mimeTypes := []string{
 		imgspecv1.MediaTypeImageManifest,
 		manifest.DockerV2Schema2MediaType,
 		imgspecv1.MediaTypeImageIndex,
 		manifest.DockerV2ListMediaType,
-		manifest.DockerV2Schema1SignedMediaType,
-		manifest.DockerV2Schema1MediaType,
 	}
+	if d.c.sys == nil || !d.c.sys.DockerDisableDestSchema1MIMETypes {
+		mimeTypes = append(mimeTypes, manifest.DockerV2Schema1SignedMediaType, manifest.DockerV2Schema1MediaType)
+	}
+	return mimeTypes
 }
 
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.

--- a/vendor/github.com/containers/image/v5/docker/docker_image_src.go
+++ b/vendor/github.com/containers/image/v5/docker/docker_image_src.go
@@ -239,7 +239,7 @@ func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo, ca
 	if err != nil {
 		return nil, 0, err
 	}
-	if err := httpResponseToError(res); err != nil {
+	if err := httpResponseToError(res, "Error fetching blob"); err != nil {
 		return nil, 0, err
 	}
 	cache.RecordKnownLocation(s.ref.Transport(), bicTransportScope(s.ref), info.Digest, newBICLocationReference(s.ref))

--- a/vendor/github.com/containers/image/v5/docker/errors.go
+++ b/vendor/github.com/containers/image/v5/docker/errors.go
@@ -14,7 +14,7 @@ var (
 	// docker V1 registry.
 	ErrV1NotSupported = errors.New("can't talk to a V1 docker registry")
 	// ErrTooManyRequests is returned when the status code returned is 429
-	ErrTooManyRequests = errors.New("too many request to registry")
+	ErrTooManyRequests = errors.New("too many requests to registry")
 )
 
 // ErrUnauthorizedForCredentials is returned when the status code returned is 401
@@ -26,9 +26,9 @@ func (e ErrUnauthorizedForCredentials) Error() string {
 	return fmt.Sprintf("unable to retrieve auth token: invalid username/password: %s", e.Err.Error())
 }
 
-// httpResponseToError translates the https.Response into an error. It returns
+// httpResponseToError translates the https.Response into an error, possibly prefixing it with the supplied context. It returns
 // nil if the response is not considered an error.
-func httpResponseToError(res *http.Response) error {
+func httpResponseToError(res *http.Response, context string) error {
 	switch res.StatusCode {
 	case http.StatusOK:
 		return nil
@@ -38,6 +38,9 @@ func httpResponseToError(res *http.Response) error {
 		err := client.HandleErrorResponse(res)
 		return ErrUnauthorizedForCredentials{Err: err}
 	default:
-		return perrors.Errorf("invalid status code from registry %d (%s)", res.StatusCode, http.StatusText(res.StatusCode))
+		if context != "" {
+			context = context + ": "
+		}
+		return perrors.Errorf("%sinvalid status code from registry %d (%s)", context, res.StatusCode, http.StatusText(res.StatusCode))
 	}
 }

--- a/vendor/github.com/containers/image/v5/types/types.go
+++ b/vendor/github.com/containers/image/v5/types/types.go
@@ -547,6 +547,8 @@ type SystemContext struct {
 	// Note that this field is used mainly to integrate containers/image into projectatomic/docker
 	// in order to not break any existing docker's integration tests.
 	DockerDisableV1Ping bool
+	// If true, dockerImageDestination.SupportedManifestMIMETypes will omit the Schema1 media types from the supported list
+	DockerDisableDestSchema1MIMETypes bool
 	// Directory to use for OSTree temporary files
 	OSTreeTmpDirPath string
 


### PR DESCRIPTION

    When migrating internal images, convert to schema2 for any
    legacy schema1 images, since recent docker registry versions
    no longer support schema1.

Required changes to containers/image are included in this PR, but can be removed once the upstream PR https://github.com/containers/image/pull/771 is merged and we update to a version including the change.