### PR TITLE
For imagestreamtags referencing ImageStreamImage, copy by tag

### DIFF
--- a/velero-plugins/migimagestream/backup.go
+++ b/velero-plugins/migimagestream/backup.go
@@ -60,9 +60,12 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 		specTag := findSpecTag(im.Spec.Tags, tag.Tag)
 		copyToTag := true
 		if specTag != nil && specTag.From != nil {
-			p.Log.Info(fmt.Sprintf("[is-backup] image tagged: %s, %s", specTag.From.Kind, specTag.From.Name))
 			// we have a tag.
-			copyToTag = false
+			p.Log.Info(fmt.Sprintf("[is-backup] image tagged: %s, %s", specTag.From.Kind, specTag.From.Name))
+			if !(specTag.From.Kind == "ImageStreamImage" && (specTag.From.Namespace == "" || specTag.From.Namespace == im.Namespace)) {
+				p.Log.Info(fmt.Sprintf("[is-backup] using tag for current namespace ImageStreamImage"))
+				copyToTag = false
+			}
 		}
 		// Iterate over items in reverse order so most recently tagged is copied last
 		for i := len(tag.Items) - 1; i >= 0; i-- {


### PR DESCRIPTION
For ImageStreamTags, when the tag references something external
(docker image, ImageStreamTag, or ImageStreamImage), we were
copying any internal images without tag and relying on the
ImageStreamTag restore to recreate the tags. This exposes us to
an upstream Velero issue where a prior ImageStreamTag restore
(the one which should have created the tag or image which this
one references) completes but the resource isn't yet available,
so the ImageStreamTag resource fails to restore.

This commit modifies the behavior for local-namespace ImageStreamImage
references -- copying these by tag into the registry rather than
restoring via the ImageStreamTag resource. The race condition still
potentially exists for references to other namespaces included in the backup
or references by ImageStreamTag.