### PR TITLE
Add migmigration labels on all resources to apply labelSelector

### DIFF
--- a/velero-plugins/main.go
+++ b/velero-plugins/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migclusterrolebindings"
+	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migcommon"
 	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migdeployment"
 	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migdeploymentconfig"
 	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migimagestream"
@@ -9,10 +11,9 @@ import (
 	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migpod"
 	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migpv"
 	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migpvc"
+	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migrolebindings"
 	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migsa"
 	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migscc"
-	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migrolebindings"
-	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migclusterrolebindings"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/build"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/buildconfig"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
@@ -37,6 +38,7 @@ func main() {
 	veleroplugin.NewServer().
 		RegisterBackupItemAction("openshift.io/01-common-backup-plugin", newCommonBackupPlugin).
 		RegisterRestoreItemAction("openshift.io/01-common-restore-plugin", newCommonRestorePlugin).
+		RegisterRestoreItemAction("openshift.io/01-migcommon-restore-plugin", newMigCommonRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/01-namespace-restore-plugin", newNamespaceRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/02-serviceaccount-restore-plugin", newServiceAccountRestorePlugin).
 		RegisterBackupItemAction("openshift.io/02-pv-backup-plugin", newPVBackupPlugin).
@@ -74,6 +76,10 @@ func newCommonBackupPlugin(logger logrus.FieldLogger) (interface{}, error) {
 
 func newCommonRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
 	return &common.RestorePlugin{Log: logger}, nil
+}
+
+func newMigCommonRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
+	return &migcommon.RestorePlugin{Log: logger}, nil
 }
 
 func newNamespaceRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {

--- a/velero-plugins/migcommon/restore.go
+++ b/velero-plugins/migcommon/restore.go
@@ -1,0 +1,55 @@
+package migcommon
+
+import (
+	"errors"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+// RestorePlugin is a restore item action plugin for Velero.
+type RestorePlugin struct {
+	Log logrus.FieldLogger
+}
+
+// AppliesTo returns a velero.ResourceSelector that applies to everything.
+func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{}, nil
+}
+
+// Execute sets a custom annotation on the item being restored.
+func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	p.Log.Info("[common-restore] Entering common migration restore plugin")
+
+	metadata, err := meta.Accessor(input.Item)
+	if err != nil {
+		return nil, err
+	}
+	// Skip cluster-scoped resources
+	if len(metadata.GetNamespace()) == 0 {
+		return nil, nil
+	}
+	name := metadata.GetName()
+	p.Log.Infof("[common-restore] common migration restore plugin for %s", name)
+
+	// Set migmigraiton label on all resources, except ServiceAccounts
+	switch input.Item.DeepCopyObject().(type) {
+	case *corev1.ServiceAccount:
+		break
+	default:
+		migMigrationLabel, exist := input.Restore.Labels[MigMigrationLabelKey]
+		if !exist {
+			return nil, errors.New("migmigration label is not found on restore")
+		}
+		labels := metadata.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels[MigratedByLabel] = migMigrationLabel
+		metadata.SetLabels(labels)
+	}
+
+	return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+}

--- a/velero-plugins/migcommon/types.go
+++ b/velero-plugins/migcommon/types.go
@@ -31,3 +31,7 @@ const ResticBackupAnnotation string = "backup.velero.io/backup-volumes"
 const NamespaceSCCAnnotationMCS string = "openshift.io/sa.scc.mcs"
 const NamespaceSCCAnnotationGroups string = "openshift.io/sa.scc.supplemental-groups"
 const NamespaceSCCAnnotationUidRange string = "openshift.io/sa.scc.uid-range"
+
+// Restored items label
+const MigMigrationLabelKey string = "migmigration"
+const MigratedByLabel string = "migration.openshift.io/migrated-by" // (migmigration UID)


### PR DESCRIPTION
Adding labels `migration.openshift.io/migrated-by` on all migrated resources during restore, except SA.

This PR will allow to delete application on the destination cluster, preventing it from running on both clusters simultaneously. 