### PR TITLE
Bug 1790564: Don't fail migration with no internal registry

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -482,7 +482,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:aad2573784f1a156972916411eb80947cdc9a4c9bb65ec8f0a6c412091c7d653"
+  digest = "1:f685c5adab92743c4220e81be5e5ce43b26288b6829463554f150194c9de9ce4"
   name = "github.com/konveyor/openshift-velero-plugin"
   packages = [
     "velero-plugins/build",
@@ -503,7 +503,7 @@
     "velero-plugins/statefulset",
   ]
   pruneopts = "NUT"
-  revision = "f718493d3789d5b9de0f029fb31deed293ed4d1d"
+  revision = "c58812cbfdd686adc02095f0a216675a6c267a78"
 
 [[projects]]
   digest = "1:bced2617aac935b7931d43bdd5fd5ef3eacbb52291c61e423afe8037f6dd95f9"

--- a/velero-plugins/migimagestream/backup.go
+++ b/velero-plugins/migimagestream/backup.go
@@ -44,9 +44,6 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 	}
 
 	internalRegistry := annotations[common.BackupRegistryHostname]
-	if len(internalRegistry) == 0 {
-		return nil, nil, errors.New("backup cluster registry not found for annotation \"openshift.io/backup-registry-hostname\"")
-	}
 	migrationRegistry := backup.Annotations[migcommon.MigrationRegistry]
 	if len(migrationRegistry) == 0 {
 		return nil, nil, errors.New("migration registry not found for annotation \"openshift.io/migration\"")
@@ -70,7 +67,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 		// Iterate over items in reverse order so most recently tagged is copied last
 		for i := len(tag.Items) - 1; i >= 0; i-- {
 			dockerImageReference := tag.Items[i].DockerImageReference
-			if strings.HasPrefix(dockerImageReference, internalRegistry) {
+			if len(internalRegistry) > 0 && strings.HasPrefix(dockerImageReference, internalRegistry) {
 				localImageCopied = true
 				destTag := ""
 				if copyToTag {

--- a/velero-plugins/migimagestreamtag/restore.go
+++ b/velero-plugins/migimagestreamtag/restore.go
@@ -2,7 +2,6 @@ package migimagestreamtag
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -41,17 +40,10 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 
 	p.Log.Info(fmt.Sprintf("[istag-restore] Restoring imagestreamtag %s", imageStreamTag.Name))
 
-	internalRegistry := annotations[common.RestoreRegistryHostname]
-	if len(internalRegistry) == 0 {
-		return nil, errors.New("restore cluster registry not found for annotation \"openshift.io/restore-registry-hostname\"")
-	}
 	backupInternalRegistry := annotations[common.BackupRegistryHostname]
-	if len(backupInternalRegistry) == 0 {
-		return nil, errors.New("backup cluster registry not found for annotation \"openshift.io/backup-registry-hostname\"")
-	}
 	p.Log.Info(fmt.Sprintf("[istag-restore] backup internal registry: %#v", backupInternalRegistry))
 	dockerImageReference := imageStreamTag.Image.DockerImageReference
-	localImage := common.HasImageRefPrefix(dockerImageReference, backupInternalRegistry)
+	localImage := len(backupInternalRegistry) > 0 && common.HasImageRefPrefix(dockerImageReference, backupInternalRegistry)
 	if localImage {
 		p.Log.Info(fmt.Sprintf("[istag-restore] Local image: %v", dockerImageReference))
 	}

--- a/velero-plugins/migpod/restore.go
+++ b/velero-plugins/migpod/restore.go
@@ -2,7 +2,6 @@ package migpod
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/konveyor/openshift-migration-plugin/velero-plugins/migcommon"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
@@ -43,10 +42,9 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		pod.Labels[migcommon.PodStageLabel] = "true"
 		pod.Spec.Affinity = nil
 	} else {
-		registry := pod.Annotations[common.RestoreRegistryHostname]
-		backupRegistry := pod.Annotations[common.BackupRegistryHostname]
-		if registry == "" {
-			return nil, fmt.Errorf("failed to find restore registry annotation")
+		backupRegistry, registry, err := common.GetSrcAndDestRegistryInfo(input.Item)
+		if err != nil {
+			return nil, err
 		}
 		common.SwapContainerImageRefs(pod.Spec.Containers, backupRegistry, registry, p.Log, input.Restore.Spec.NamespaceMapping)
 		common.SwapContainerImageRefs(pod.Spec.InitContainers, backupRegistry, registry, p.Log, input.Restore.Spec.NamespaceMapping)

--- a/vendor/github.com/konveyor/openshift-velero-plugin/velero-plugins/buildconfig/restore.go
+++ b/vendor/github.com/konveyor/openshift-velero-plugin/velero-plugins/buildconfig/restore.go
@@ -2,7 +2,6 @@ package buildconfig
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/build"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
@@ -59,15 +58,7 @@ func (p *RestorePlugin) updateSecretsAndDockerRefs(buildconfig buildv1API.BuildC
 	}
 
 	registry := buildconfig.Annotations[common.RestoreRegistryHostname]
-	if registry == "" {
-		err = fmt.Errorf("failed to find restore registry annotation")
-		return buildconfig, err
-	}
 	backupRegistry := buildconfig.Annotations[common.BackupRegistryHostname]
-	if backupRegistry == "" {
-		err = fmt.Errorf("failed to find backup registry annotation")
-		return buildconfig, err
-	}
 
 	newCommonSpec, err := build.UpdateCommonSpec(buildconfig.Spec.CommonSpec, registry, backupRegistry, secretList, p.Log, namespaceMapping)
 	if err != nil {

--- a/vendor/github.com/konveyor/openshift-velero-plugin/velero-plugins/common/shared.go
+++ b/vendor/github.com/konveyor/openshift-velero-plugin/velero-plugins/common/shared.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -49,7 +48,8 @@ func GetRegistryInfo(major, minor string, log logrus.FieldLogger) (string, error
 	} else if intVersion <= 11 {
 		registrySvc, err := cClient.Services("default").Get("docker-registry", metav1.GetOptions{})
 		if err != nil {
-			return "", err
+			// Return empty registry host but no error; registry not found
+			return "", nil
 		}
 		internalRegistry := registrySvc.Spec.ClusterIP + ":" + strconv.Itoa(int(registrySvc.Spec.Ports[0].Port))
 		log.Info("[GetRegistryInfo] value from clusterIP")
@@ -66,7 +66,7 @@ func GetRegistryInfo(major, minor string, log logrus.FieldLogger) (string, error
 		}
 		internalRegistry := serverConfig.ImagePolicyConfig.InternalRegistryHostname
 		if len(internalRegistry) == 0 {
-			return "", errors.New("InternalRegistryHostname not found")
+			return "", nil
 		}
 		log.Info("[GetRegistryInfo] value from clusterIP")
 		return internalRegistry, nil

--- a/vendor/github.com/konveyor/openshift-velero-plugin/velero-plugins/common/util.go
+++ b/vendor/github.com/konveyor/openshift-velero-plugin/velero-plugins/common/util.go
@@ -87,6 +87,9 @@ func ParseLocalImageReference(s, prefix string) (*LocalImageReference, error) {
 // SwapContainerImageRefs updates internal image references from
 // backup registry to restore registry pathnames
 func SwapContainerImageRefs(containers []corev1API.Container, oldRegistry, newRegistry string, log logrus.FieldLogger, namespaceMapping map[string]string) {
+	if oldRegistry == "" || newRegistry == "" {
+		return
+	}
 	for n, container := range containers {
 		imageRef := container.Image
 		log.Infof("[util] container image ref %s", imageRef)
@@ -107,13 +110,7 @@ func GetSrcAndDestRegistryInfo(item runtime.Unstructured) (string, string, error
 		return "", "", err
 	}
 	backupRegistry := annotations[BackupRegistryHostname]
-	if backupRegistry == "" {
-		return "", "", fmt.Errorf("failed to find backup registry annotation")
-	}
 	restoreRegistry := annotations[RestoreRegistryHostname]
-	if restoreRegistry == "" {
-		return "", "", fmt.Errorf("failed to find restore registry annotation")
-	}
 	return backupRegistry, restoreRegistry, nil
 }
 


### PR DESCRIPTION
This is to support migrations when there's no internal registry on destination but no
internal images to copy from src.