### PR TITLE
Always return the item in plugins unless there's an error

### DIFF
--- a/velero-plugins/migcommon/restore.go
+++ b/velero-plugins/migcommon/restore.go
@@ -29,7 +29,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	}
 	// Skip cluster-scoped resources
 	if len(metadata.GetNamespace()) == 0 {
-		return nil, nil
+		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
 	}
 	name := metadata.GetName()
 	p.Log.Infof("[common-restore] common migration restore plugin for %s", name)


### PR DESCRIPTION
When returning the unmodified item in the migration common restore
plugin in the case of cluster-scoped resources, return the item rather
than nil. Returning nil results in velero errors like this:
    error preparing customresourcedefinitions.apiextensions.k8s.io/foos.example.foo.com:
      rpc error: code = Aborted desc = plugin panicked: runtime error:
      invalid memory address or nil pointer dereference