### PR TITLE
update the imagestream retries to 7

### DIFF
--- a/velero-plugins/migimagestream/shared.go
+++ b/velero-plugins/migimagestream/shared.go
@@ -33,13 +33,13 @@ func copyImage(log logrus.FieldLogger, src, dest string, sourceCtx, destinationC
 		return []byte{}, fmt.Errorf("Invalid destination name %s: %v", dest, err)
 	}
 
-	// Let's retry the image copy up to 10 times
+	// Let's retry the image copy up to 7 times
 	// Each retry will wait 5 seconds longer
 	// Let's log a warning if we encounter `blob unknown to registry`
 	// TODO: Change this to only retry on specific errors from image copy
 	retryWait := 5
 	log.Info(fmt.Sprintf("copying image: %s; will attempt up to 5 times...", src))
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 7; i++ {
 		manifest, err := copy.Image(context.Background(), policyContext, destRef, srcRef, &copy.Options{
 			SourceCtx:      sourceCtx,
 			DestinationCtx: destinationCtx,
@@ -53,7 +53,7 @@ func copyImage(log logrus.FieldLogger, src, dest string, sourceCtx, destinationC
 		if err != nil {
 			log.Warn(err)
 		}
-		log.Info(fmt.Sprintf("attempt #%v failed, waiting %vs and then retrying", i, retryWait))
+		log.Info(fmt.Sprintf("attempt #%v failed, waiting %vs and then retrying", i+1, retryWait))
 		time.Sleep(time.Duration(retryWait) * time.Second)
 		retryWait += 5
 	}


### PR DESCRIPTION
Since the backoff time increases every time we retry,
we want to make sure for images that are always going to fail
we don't wait too long. This would still give enough time/retries
for images that are going through transient errors, so a happy
middle ground